### PR TITLE
Remove "bottle :unneeded" from formula

### DIFF
--- a/Formula/woke.rb
+++ b/Formula/woke.rb
@@ -6,7 +6,6 @@ class Woke < Formula
   desc "Detect non-inclusive language in your source code."
   homepage "https://getwoke.tech"
   version "0.15.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Many of the `brew` commands log this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the get-woke/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/get-woke/homebrew-tap/Formula/woke.rb:9
```

This removes the `bottle :unneeded` from the formula.